### PR TITLE
Bump Dependencies (ttf2woff2 + devDependencies)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,14 +34,14 @@
     "svgicons2svgfont": "^9.0.3",
     "ttf2eot": "^2.0.0",
     "ttf2woff": "^2.0.1",
-    "ttf2woff2": "^2.0.3",
+    "ttf2woff2": "^3.0.0",
     "underscore": "^1.9.1",
     "url-join": "^4.0.0"
   },
   "devDependencies": {
-    "file-type": "^9.0.0",
-    "mocha": "^5.2.0",
+    "file-type": "^12.0.1",
+    "mocha": "^6.1.4",
     "node-sass": "^4.9.3",
-    "read-chunk": "^2.1.0"
+    "read-chunk": "^3.2.0"
   }
 }


### PR DESCRIPTION
ttf2woff2 3.0.0 supports node 12

mocha tests are green