### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,20 +28,20 @@
   },
   "dependencies": {
     "handlebars": "^4.0.11",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.4",
     "q": "^1.1.2",
     "svg2ttf": "^5.0.0",
     "svgicons2svgfont": "^9.0.3",
     "ttf2eot": "^2.0.0",
     "ttf2woff": "^2.0.1",
-    "ttf2woff2": "^3.0.0",
+    "ttf2woff2": "^4.0.1",
     "underscore": "^1.9.1",
     "url-join": "^4.0.0"
   },
   "devDependencies": {
-    "file-type": "^12.0.1",
-    "mocha": "^6.1.4",
-    "node-sass": "^4.9.3",
+    "file-type": "^16.1.0",
+    "mocha": "^8.2.1",
+    "node-sass": "^5.0.0",
     "read-chunk": "^3.2.0"
   }
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -6,7 +6,7 @@ var assert = require('assert')
 var sass = require('node-sass')
 var Q = require('q')
 var readChunk = require('read-chunk')
-var getFileType = require('file-type')
+var FileType = require('file-type')
 
 var webfontsGenerator = require('../src/index')
 
@@ -36,7 +36,7 @@ describe('webfont', function() {
 	})
 
 	it('generates all fonts and css files', function(done) {
-		webfontsGenerator(OPTIONS, function(err) {
+		webfontsGenerator(OPTIONS, async function(err) {
 			if (err) return done(err)
 
 			var destFiles = fs.readdirSync(DEST)
@@ -50,7 +50,7 @@ describe('webfont', function() {
 				var DETECTABLE = ['ttf', 'woff', 'woff2', 'eot']
 				if (_.contains(DETECTABLE, type)) {
 					var chunk = readChunk.sync(filepath, 0, 262)
-					var filetype = getFileType(chunk)
+					var filetype = await FileType.fromBuffer(chunk)
 					assert.equal(type, filetype && filetype.ext, 'ttf filetype is correct')
 				}
 			}


### PR DESCRIPTION
The ttf2woff2 upgrade fixes a warning in Node ≥ 14.6.0: nfroidure/ttf2woff2#62.