### PR TITLE
Expose generateHtml for using the html file also if writeFiles is false

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,9 +100,14 @@ var webfont = function(options, done) {
 		.then(function(result) {
 			if (options.writeFiles) writeResult(result, options)
 
+			result.generateHtml = function() {
+				return renderHtml(options)
+			}
+
 			result.generateCss = function(urls) {
 				return renderCss(options, urls)
 			}
+
 			done(null, result)
 		})
 		.catch(function(err) { done(err) })

--- a/tests/test.js
+++ b/tests/test.js
@@ -66,7 +66,7 @@ describe('webfont', function() {
 		})
 	})
 
-	it('returns object with fonts and function generateCss()', function() {
+	it('returns object with fonts and functions generateCss(), generateHtml()', function() {
 		webfontsGenerator(OPTIONS, function(err, result) {
 			assert(result.svg)
 			assert(result.ttf)
@@ -74,6 +74,10 @@ describe('webfont', function() {
 			assert.equal(typeof result.generateCss, 'function')
 			var css = result.generateCss()
 			assert.equal(typeof css, 'string')
+
+			assert.equal(typeof result.generateHtml, 'function')
+			var html = result.generateHtml()
+			assert.equal(typeof html, 'string')
 		})
 	})
 


### PR DESCRIPTION
You should have access to the html template file, also if ``writeFiles`` was set to ``false``. The use case is described in the ``webfonts-loader`` for webpack:

https://github.com/jeerbl/webfonts-loader/issues/138