### PR TITLE
Add urls parameter to renderHtml

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,8 +102,8 @@ var webfont = function(options, done) {
 		.then(function(result) {
 			if (options.writeFiles) writeResult(result, options)
 
-			result.generateHtml = function() {
-				return renderHtml(options)
+			result.generateHtml = function(urls) {
+				return renderHtml(options, urls)
 			}
 
 			result.generateCss = function(urls) {

--- a/src/renderHtml.js
+++ b/src/renderHtml.js
@@ -9,7 +9,7 @@ handlebars.registerHelper('removePeriods', function (selector) {
 	return selector.replace(/\./, '');
 });
 
-var renderHtml = function(options) {
+var renderHtml = function(options, urls) {
 	var source = fs.readFileSync(options.htmlTemplate, 'utf8')
 	var template = handlebars.compile(source)
 
@@ -18,7 +18,7 @@ var renderHtml = function(options) {
 	// have path to fonts that is relative to html file location.
 	var styles = renderCss(_.extend({}, options, {
 		cssFontPath: htmlFontsPath
-	}))
+	}), urls)
 
 	var ctx = _.extend({
 		names: options.names,


### PR DESCRIPTION
The urls for generating css should also pass to ``renderHtml``, because the ``renderHtml`` function uses the ``renderCss``  function.