### PR TITLE
Add font-display: block to default templates

### DIFF
--- a/templates/css.hbs
+++ b/templates/css.hbs
@@ -1,5 +1,6 @@
 @font-face {
 	font-family: "{{fontName}}";
+	font-display: block;
 	src: {{{src}}};
 }
 

--- a/templates/scss.hbs
+++ b/templates/scss.hbs
@@ -1,5 +1,6 @@
 @font-face {
 	font-family: "{{fontName}}";
+	font-display: block;
 	src: {{{src}}};
 }
 


### PR DESCRIPTION
It’s not helpful for the browser to substitute another font for the icon font while it’s loading.

This suppresses a warning from the Lighthouse performance analyzer: https://github.com/GoogleChrome/lighthouse/issues/10127#issuecomment-567093362.